### PR TITLE
remove unnecessary crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braid-server",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "A federated server for interconnecting collaboration apps",
   "bin": {
     "braid-server": "./braid-server.js"
@@ -15,7 +15,6 @@
     "async": "^1.2.1",
     "bcrypt": "^0.8.3",
     "command-line-args": "^0.5.9",
-    "crypto": "0.0.3",
     "dns": "^0.2.2",
     "express": "^4.12.4",
     "fs": "0.0.2",


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.